### PR TITLE
added dateutil fix to conrad's improved code

### DIFF
--- a/play_radio.py
+++ b/play_radio.py
@@ -18,8 +18,11 @@ def parse_date(name):
     date = re.search("([\d][-/]?){6}|([\d][-/]?){8}", name)
     if date:
         date = parse(date.group(0), yearfirst=True)
+        #Dateutil bug sometimes returns 21st century. Force 20th 
+        if date.year > 1999:
+            date = date.replace(year = date.year - 100)
     else:
-        # need to define a value for unpasrseable name
+        # need to define a value for unparseable name
         pass
     return date
 


### PR DESCRIPTION
Fixed the dateutil problem by subtracting 100 from any datetime object with a year value > 2000 in the parse_date() function.  So a filename "xxxx340123" gets recognized by dateutil as 2034 but is then forced into 1934.  Worth note is that any file with a date in the file name legitimately after the year 2000 will also be forced to 19xx.
